### PR TITLE
Introduce sequencePath, versionTimestampPath and versionSequencePath

### DIFF
--- a/eventstreams.bs
+++ b/eventstreams.bs
@@ -33,8 +33,11 @@ When more resources are used, these pages, or `tree:Node`s, will be structured a
 Therefore we will use the terms *root node* for the first page, and *subsequent node* for every next page in the structure.
 
 In the root node, the client will expect these properties to be described on the `ldes:EventStream` entity:
- * `ldes:timestampPath`: this is a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths) that identifies an `xsd:dateTime` literal within each member. This timestamp determines the chronological order in which members of the event stream are added. When `ldes:timestampPath` is set, no member can be added to the LDES with a timestamp earlier than the latest published member.
+ * `ldes:timestampPath`: this is a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths) (all further *Path properties are as well) that sets the chronological time with a `xsd:dateTime` literal within each member. This timestamp determines the chronological order in which members of the event stream are added. When `ldes:timestampPath` is set, no member can be added to the LDES with a timestamp earlier than the latest published member.
+ * `ldes:sequencePath`: when the LDES producer wants to make clear what the ordering is within members with the same timestamp for the `ldes:timestampPath`, this property defines, based on the [[!xpath-functions-31]] [comparison operator](https://www.w3.org/TR/xpath-functions-31/#func-compare), what xsd-literals define the order of processing. When no `ldes:timestampPath` has been set, the `ldes:sequencePath` defines the sequence for all members in the LDES.
  * `ldes:versionOfPath`: when your entities are versioned, this property points at the object that tells you what entity it is a version of (e.g., `dcterms:isVersionOf`).
+ * `ldes:versionTimestampPath`: when those versions are not published chronologically, LDES providers have the possibility to indicate a different version timestamp to establish the latest version.
+ * `ldes:versionSequencePath`: when the versions do not follow the order in `ldes:timestampPath` and `ldes:sequencePath`, and for when `ldes:versionTimestampPath` are the same for multiple members, or for when this property is not set. E.g., for out of order publishing of `v0.1` → `v0.2`, in which `v0.2` may have been published by the server before `v0.1`.
  * `tree:shape`: a [[!SHACL]] shape that can be used to select a search tree in the discovery phase, as well as to validate the members in the event stream.
  * `tree:view`: connects the collection to the current page, or points to one specific root node after dereferencing the `ldes:EventStream` identifier.
 
@@ -116,8 +119,8 @@ A consumer can also understand how to process the event stream in a way that the
  * [`ldes:transactionFinalizedPath`](#voc-transactionFinalizedPath) - points at the object 
  * [`ldes:transactionFinalizedObject`](#voc-transactionFinalizedObject) - the value that the object needs to be in order to be finalized. Defaults to the `"true"^^xsd:boolean`.
 
-If one of the processors in a pipeline relies on transactions, the LDES client MUST force to emit the members in chronological order according to the `ldes:timestampPath`.
-When processing multiple members with the same `ldes:timestampPath`, the client MUST ensure the member that finalizes the transaction is emitted last.
+If one of the processors in a pipeline relies on transactions, the LDES client MUST force to emit the members in chronological order according to the `ldes:timestampPath` and `ldes:sequencePath`.
+When processing multiple members of the transaction with the same `ldes:timestampPath`, the client MUST ensure the member that finalizes the transaction is emitted last.
 
 When the IRI in the object of the `tree:member` triple is also used as a named graph, an LDES consumer MAY assume the payload of the upsert is in the named graph.
 A consumer MUST implement a way to find back this group of triples in case an update or deletion comes in.
@@ -170,6 +173,7 @@ Multiple properties can then be added to make the scope of members that are kept
 
 When using the current time in calculations, the consumer MUST take into account a safe buffer to mitigate clock inaccuracies.
 The `ldes:timestampPath` points at the timestamp in the member that can be compared with the current time minus the durations.
+When the `ldes:versionTimestampPath` has been set, the two version durations are to be compared with this timestamp.
 
 Historically, there are more specific type of retention policies that MUST remain supported although their use is discouraged in favor of the just introduced retention policy design.
 These retention policies types are:
@@ -194,15 +198,43 @@ The class `ldes:EventStream` is a subclass of `tree:Collection`. The specializat
 
 The path to the `xsd:dateTime` literal in each member that defines the order of the event stream.
 
-**Domain:** `ldes:EventStream` or `ldes:RetentionPolicy`
+**Domain:** `ldes:EventStream`
 
 **Range:** a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths)
+
+## ldes:sequencePath ## {#voc-sequencePath}
+
+The path to an xsd literal in each member that defines the order of the event stream in addition to the `ldes:timestampPath`.
+
+**Domain:** `ldes:EventStream`
+
+**Range:** a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths)
+
 
 ## ldes:versionOfPath ## {#voc-versionOfPath}
 
 The path to the IRI in each member that defines the entity of which this member is a version.
 
-**Domain:** `ldes:EventStream` or `ldes:RetentionPolicy`
+**Domain:** `ldes:EventStream`
+
+**Range:** a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths)
+
+
+## ldes:versionTimestampPath ## {#voc-versionTimestampPath}
+
+For out of order event streams, this defines the path to the `xsd:dateTime` literal in each member that defines the order of versioned members.
+
+Only relevant when the `ldes:versionOfPath` has been set.
+
+**Domain:** `ldes:EventStream`
+
+**Range:** a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths)
+
+## ldes:versionSequencePath ## {#voc-versionSequencePath}
+
+For out of order event streams, this defines the path to an xsd literal in each member that defines the order of the event stream in addition to the `ldes:versionTimestampPath`.
+
+**Domain:** `ldes:EventStream`
 
 **Range:** a [SHACL property path](https://www.w3.org/TR/shacl/#property-paths)
 

--- a/vocabulary.ttl
+++ b/vocabulary.ttl
@@ -52,13 +52,13 @@ ldes:startingFrom a rdf:Property ;
                      rdfs:label "Starting from"@en;
                      rdfs:comment "The search tree only keeps members starting a certain timestamp."@en ;
                      rdfs:range xsd:dateTime ;
-		     rdfs:domain ldes:RetentionPolicy .
+                     rdfs:domain ldes:RetentionPolicy .
 
 ldes:versionDuration a rdf:Property ;
                      rdfs:label "Version duration"@en;
                      rdfs:comment "The search tree only keeps its versions, for which an `ldes:versionAmount` MUST have been set, only during a specific window. "@en ;
                      rdfs:range xsd:duration ;
-		     rdfs:domain ldes:RetentionPolicy .
+                     rdfs:domain ldes:RetentionPolicy .
 
 ldes:versionAmount a rdf:Property ;
                      rdfs:label "Version amount"@en;
@@ -80,11 +80,29 @@ ldes:fullLogDuration a rdf:Property ;
 
 ldes:versionOfPath a rdf:Property ;
                    rdfs:label "versionOf Path"@en;
-                   rdfs:comment "SHACL property path to the non-versioned IRI of the entity."@en .
+                   rdfs:comment "SHACL property path to the non-versioned IRI of the entity."@en ;
+                   rdfs:domain ldes:EventStream .
 
 ldes:timestampPath a rdf:Property ;
                    rdfs:label "Timestamp Path"@en;
-                   rdfs:comment "SHACL property path to the xsd:dateTime literal in each member that defines the order of the event stream."@en .
+                   rdfs:comment "SHACL property path to the xsd:dateTime literal in each member that defines the order of the event stream."@en ;
+                   rdfs:domain ldes:EventStream .
+
+ldes:sequencePath a rdf:Property ;
+                  rdfs:label "Sequence Path"@en;
+                  rdfs:comment "SHACL property path to an xsd literal in each member that defines the order of the event stream in addition to the timestampPath."@en ;
+                  rdfs:domain ldes:EventStream .
+
+ldes:versionTimestampPath a rdf:Property ;
+                   rdfs:label "Version Timestamp Path"@en;
+                   rdfs:comment "For out of order event streams: a SHACL property path to the xsd:dateTime literal in each member that defines the order of versioned members."@en ;
+                   rdfs:domain ldes:EventStream .
+
+ldes:versionSequencePath a rdf:Property ;
+                  rdfs:label "Version Sequence Path"@en;
+                  rdfs:comment "For out of order event streams: a SHACL property path to an xsd literal in each member that defines the order of the event stream in addition to the versionTimestampPath."@en ;
+                  rdfs:domain ldes:EventStream .
+
 
 ldes:versionMaterializationOf a rdf:Property ;
                    rdfs:label "Version Materialization Of"@en;
@@ -93,52 +111,52 @@ ldes:versionMaterializationOf a rdf:Property ;
                    rdfs:domain tree:Collection .
 
 ldes:versionMaterializationUntil a rdf:Property ;
-                   rdfs:label "Version Materialization Until"@en;
-                   rdfs:comment "Timestamp until versions were processed"@en ;
-                   rdfs:range xsd:dateTime ;
-                   rdfs:domain tree:Collection .
+                                 rdfs:label "Version Materialization Until"@en;
+                                 rdfs:comment "Timestamp until versions were processed"@en ;
+                                 rdfs:range xsd:dateTime ;
+                                 rdfs:domain tree:Collection .
 
 ldes:versionCreatePath a rdf:Property ;
                        rdfs:label "Version Create Path"@en ;
-		       rdfs:comment "Path indicating where you can do an object check on whether the member represents a create. Defaults to rdf:type."@en ;
-		       rdfs:domain ldes:EventStream .
+                       rdfs:comment "Path indicating where you can do an object check on whether the member represents a create. Defaults to rdf:type."@en ;
+                       rdfs:domain ldes:EventStream .
 
 ldes:versionUpdatePath a rdf:Property ;
                        rdfs:label "Version Update Path"@en ;
-		       rdfs:comment "Path indicating where you can do an object check on whether the member represents an update. Defaults to rdf:type."@en ;
-		       rdfs:domain ldes:EventStream .
+                       rdfs:comment "Path indicating where you can do an object check on whether the member represents an update. Defaults to rdf:type."@en ;
+                       rdfs:domain ldes:EventStream .
 
 ldes:versionDeletePath a rdf:Property ;
                        rdfs:label "Version Delete Path"@en ;
-		       rdfs:comment "Path indicating where you can do an object check on whether the member represents a delete. Defaults to rdf:type."@en ;
-		       rdfs:domain ldes:EventStream .
+                       rdfs:comment "Path indicating where you can do an object check on whether the member represents a delete. Defaults to rdf:type."@en ;
+                       rdfs:domain ldes:EventStream .
 
 ldes:versionCreateObject a rdf:Property ;
                        rdfs:label "Version Create Object"@en ;
-		       rdfs:comment "If the RDF object matches the object in the version create path, the member represents a create."@en ;
-		       rdfs:domain ldes:EventStream .
+                       rdfs:comment "If the RDF object matches the object in the version create path, the member represents a create."@en ;
+                       rdfs:domain ldes:EventStream .
 
 ldes:versionUpdateObject a rdf:Property ;
                        rdfs:label "Version Update Object"@en ;
-		       rdfs:comment "If the RDF object matches the object in the version update path, the member represents an update."@en ;
-		       rdfs:domain ldes:EventStream .
+                       rdfs:comment "If the RDF object matches the object in the version update path, the member represents an update."@en ;
+                       rdfs:domain ldes:EventStream .
 
 ldes:versionDeleteObject a rdf:Property ;
                        rdfs:label "Version Delete Object"@en ;
-		       rdfs:comment "If the RDF object matches the object in the version delete path, the member represents a delete."@en ;
-		       rdfs:domain ldes:EventStream .
+                       rdfs:comment "If the RDF object matches the object in the version delete path, the member represents a delete."@en ;
+                       rdfs:domain ldes:EventStream .
 
 ldes:transactionPath a rdf:Property ;
-                       rdfs:label "Transaction Path"@en ;
-		       rdfs:comment "Path indicating how a member indicates whether it is part of a transaction."@en ;
-		       rdfs:domain ldes:EventStream .
+                     rdfs:label "Transaction Path"@en ;
+                     rdfs:comment "Path indicating how a member indicates whether it is part of a transaction."@en ;
+                     rdfs:domain ldes:EventStream .
 
 ldes:transactionFinalizedPath a rdf:Property ;
                               rdfs:label "Transaction Finalized Path"@en ;
-			      rdfs:comment "Path indicating whether the transaction has been finalized."@en ;
-			      rdfs:domain ldes:EventStream .
+                              rdfs:comment "Path indicating whether the transaction has been finalized."@en ;
+                              rdfs:domain ldes:EventStream .
 
 ldes:transactionFinalizedObject a rdf:Property ;
-                              rdfs:label "Transaction Finalized Object"@en ;
-			      rdfs:comment "If the RDF object matches the object in the transaction finalized path, the member indicates the transaction has been finalized."@en ;
-			      rdfs:domain ldes:EventStream .
+                                rdfs:label "Transaction Finalized Object"@en ;
+                                rdfs:comment "If the RDF object matches the object in the transaction finalized path, the member indicates the transaction has been finalized."@en ;
+                                rdfs:domain ldes:EventStream .


### PR DESCRIPTION
Fix #76

Also fixes indenting in the vocabulary.ttl

I also saw the JSON-LD context needs to be updated, but this can be done after all PRs are done.

[PREVIEW](https://github.com/user-attachments/files/21036017/LinkedDataEventStreams-PR76-2025-07-03.pdf)
